### PR TITLE
Rename NodeFactory variables from context to factory

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -82,14 +82,14 @@ namespace ILCompiler.DependencyAnalysis
                 return "Embedded pointer to " + Target.MangledName;
             }
 
-            protected override void OnMarked(NodeFactory context)
+            protected override void OnMarked(NodeFactory factory)
             {
                 // We don't want the child in the parent collection unless it's necessary.
                 // Only when this node gets marked, the parent node becomes the actual parent.
                 _parentNode.AddEmbeddedObject(this);
             }
 
-            public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+            public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
             {
                 return new[]
                 {
@@ -128,9 +128,9 @@ namespace ILCompiler.DependencyAnalysis
                 _onMarkedCallback = onMarkedCallback;
             }
 
-            protected override void OnMarked(NodeFactory context)
+            protected override void OnMarked(NodeFactory factory)
             {
-                base.OnMarked(context);
+                base.OnMarked(factory);
                 _onMarkedCallback(this);
             }
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -98,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             var dependencies = new DependencyList();
 
@@ -108,12 +108,12 @@ namespace ILCompiler.DependencyAnalysis
             return dependencies;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -593,10 +593,10 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             List<CombinedDependencyListEntry> dynamicNodes = new List<DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry>();
-            dynamicNodes.Add(new CombinedDependencyListEntry(context.EETypeOptionalFields(_optionalFieldsBuilder), null, "EEType optional fields"));
+            dynamicNodes.Add(new CombinedDependencyListEntry(factory.EETypeOptionalFields(_optionalFieldsBuilder), null, "EEType optional fields"));
             return dynamicNodes;
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -35,12 +35,12 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
@@ -47,6 +47,6 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         // At minimum, Target needs to be reported as a static dependency by inheritors.
-        public abstract override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context);
+        public abstract override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -76,17 +76,17 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -34,25 +34,25 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private ISymbolNode GetGCStaticEETypeNode(NodeFactory context)
+        private ISymbolNode GetGCStaticEETypeNode(NodeFactory factory)
         {
             // TODO Replace with better gcDesc computation algorithm when we add gc handling to the type system
-            bool[] gcDesc = new bool[_type.GCStaticFieldSize / context.Target.PointerSize + 1];
-            return context.GCStaticEEType(gcDesc);
+            bool[] gcDesc = new bool[_type.GCStaticFieldSize / factory.Target.PointerSize + 1];
+            return factory.GCStaticEEType(gcDesc);
         }
 
-        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList dependencyList = new DependencyList();
             
-            if (context.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            if (factory.TypeInitializationManager.HasEagerStaticConstructor(_type))
             {
-                dependencyList.Add(context.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
+                dependencyList.Add(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
             }
 
-            dependencyList.Add(context.GCStaticsRegion, "GCStatics Region");
-            dependencyList.Add(GetGCStaticEETypeNode(context), "GCStatic EEType");
-            dependencyList.Add(context.GCStaticIndirection(_type), "GC statics indirection");
+            dependencyList.Add(factory.GCStaticsRegion, "GCStatics Region");
+            dependencyList.Add(GetGCStaticEETypeNode(factory), "GCStatic EEType");
+            dependencyList.Add(factory.GCStaticIndirection(_type), "GC statics indirection");
             return dependencyList;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -75,16 +75,16 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void SetDispatchMapIndex(NodeFactory context, int index)
+        public void SetDispatchMapIndex(NodeFactory factory, int index)
         {
             _dispatchMapTableIndex = index;
-            ((EETypeNode)context.ConstructedTypeSymbol(_type)).SetDispatchMapIndex(_dispatchMapTableIndex);
+            ((EETypeNode)factory.ConstructedTypeSymbol(_type)).SetDispatchMapIndex(_dispatchMapTableIndex);
         }
 
-        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             var result = new DependencyList();
-            result.Add(context.InterfaceDispatchMapIndirection(_type), "Interface dispatch map indirection node");
+            result.Add(factory.InterfaceDispatchMapIndirection(_type), "Interface dispatch map indirection node");
             return result;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -83,16 +83,16 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList dependencies = null;
 
             TypeDesc owningType = _method.OwningType;
-            if (context.TypeInitializationManager.HasEagerStaticConstructor(owningType))
+            if (factory.TypeInitializationManager.HasEagerStaticConstructor(owningType))
             {
                 if (dependencies == null)
                     dependencies = new DependencyList();
-                dependencies.Add(context.EagerCctorIndirection(owningType.GetStaticConstructor()), "Eager .cctor");
+                dependencies.Add(factory.EagerCctorIndirection(owningType.GetStaticConstructor()), "Eager .cctor");
             }
 
             if (_ehInfo != null && _ehInfo.Relocs != null)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -86,12 +86,12 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            if (context.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            if (factory.TypeInitializationManager.HasEagerStaticConstructor(_type))
             {
                 var result = new DependencyList();
-                result.Add(context.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
+                result.Add(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
                 return result;
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
@@ -79,17 +79,17 @@ namespace ILCompiler.DependencyAnalysis
             _offset = offset;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             return new DependencyListEntry[] { new DependencyListEntry(_object, "ObjectAndOffsetDependency") };
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -80,15 +80,15 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            DependencyList dependencies = ComputeNonRelocationBasedDependencies(context);
-            Relocation[] relocs = GetData(context, true).Relocs;
+            DependencyList dependencies = ComputeNonRelocationBasedDependencies(factory);
+            Relocation[] relocs = GetData(factory, true).Relocs;
 
             if (relocs != null)
             {
@@ -107,12 +107,12 @@ namespace ILCompiler.DependencyAnalysis
                 return dependencies;
         }
 
-        protected virtual DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        protected virtual DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -319,7 +319,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void BuildCFIMap(NodeFactory context, ObjectNode node)
+        public void BuildCFIMap(NodeFactory factory, ObjectNode node)
         {
             _offsetToCfis.Clear();
             _offsetToCfiStart.Clear();
@@ -353,7 +353,7 @@ namespace ILCompiler.DependencyAnalysis
                     string blobSymbolName = "_unwind" + (i++).ToStringInvariant() + _currentNodeName;
 
                     ObjectNodeSection section = ObjectNodeSection.XDataSection;
-                    if (node.ShouldShareNodeAcrossModules(context) && context.Target.OperatingSystem == TargetOS.Windows)
+                    if (node.ShouldShareNodeAcrossModules(factory) && factory.Target.OperatingSystem == TargetOS.Windows)
                     {
                         section = section.GetSharedSection(blobSymbolName);
                         CreateCustomSection(section);
@@ -380,7 +380,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     // TODO: Currently we get linker errors if we emit frame info for shared types.
                     //       This needs follow-up investigation.
-                    if (!node.ShouldShareNodeAcrossModules(context))
+                    if (!node.ShouldShareNodeAcrossModules(factory))
                     {
                         // For window, just emit the frame blob (UNWIND_INFO) as a whole.
                         EmitWinFrameInfo(start, end, len, blobSymbolName);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -99,25 +99,25 @@ namespace ILCompiler.DependencyAnalysis
             return true;
         }
 
-        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             if (_id == ReadyToRunHelperId.VirtualCall)
             {
                 DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
-                dependencyList.Add(context.VTable(((MethodDesc)_target).OwningType), "ReadyToRun Virtual Method Call Target VTable");
+                dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
+                dependencyList.Add(factory.VTable(((MethodDesc)_target).OwningType), "ReadyToRun Virtual Method Call Target VTable");
                 return dependencyList;
             }
             else if (_id == ReadyToRunHelperId.InterfaceDispatch)
             {
                 DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Interface Method Call");
+                dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Interface Method Call");
                 return dependencyList;
             }
             else if (_id == ReadyToRunHelperId.ResolveVirtualFunction)
             {
                 DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
+                dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
                 return dependencyList;
             }
             else

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -50,14 +50,14 @@ namespace ILCompiler.DependencyAnalysis
             return ((ISymbolNode)this).MangledName;
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            return new DependencyListEntry[] { new DependencyListEntry(context.StringData(_data), "string contents") };
+            return new DependencyListEntry[] { new DependencyListEntry(factory.StringData(_data), "string contents") };
         }
 
-        protected override void OnMarked(NodeFactory context)
+        protected override void OnMarked(NodeFactory factory)
         {
-            context.StringTable.AddEmbeddedObject(this);
+            factory.StringTable.AddEmbeddedObject(this);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -38,27 +38,27 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private ISymbolNode GetGCStaticEETypeNode(NodeFactory context)
+        private ISymbolNode GetGCStaticEETypeNode(NodeFactory factory)
         {
             // TODO Replace with better gcDesc computation algorithm when we add gc handling to the type system
             // TODO This logic should be shared with GCStaticsNode.
-            bool[] gcDesc = new bool[_type.ThreadStaticFieldSize / context.Target.PointerSize + 1];
-            return context.GCStaticEEType(gcDesc);
+            bool[] gcDesc = new bool[_type.ThreadStaticFieldSize / factory.Target.PointerSize + 1];
+            return factory.GCStaticEEType(gcDesc);
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             DependencyListEntry[] result;
-            if (context.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            if (factory.TypeInitializationManager.HasEagerStaticConstructor(_type))
             {
                 result = new DependencyListEntry[3];
-                result[2] = new DependencyListEntry(context.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
+                result[2] = new DependencyListEntry(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
             }
             else
                 result = new DependencyListEntry[2];
 
-            result[0] = new DependencyListEntry(context.ThreadStaticsRegion, "ThreadStatics Region");
-            result[1] = new DependencyListEntry(GetGCStaticEETypeNode(context), "ThreadStatic EEType");
+            result[0] = new DependencyListEntry(factory.ThreadStaticsRegion, "ThreadStatics Region");
+            result[1] = new DependencyListEntry(GetGCStaticEETypeNode(factory), "ThreadStatic EEType");
             return result;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -20,10 +20,10 @@ namespace ILCompiler.DependencyAnalysis
         bool _shouldBuildFullVTable;
         List<MethodDesc> _slots = new List<MethodDesc>();
 
-        public VTableSliceNode(TypeDesc type, NodeFactory context)
+        public VTableSliceNode(TypeDesc type, NodeFactory factory)
         {
             _type = type;
-            if (context.CompilationModuleGroup.ShouldProduceFullType(_type))
+            if (factory.CompilationModuleGroup.ShouldProduceFullType(_type))
             {
                 _shouldBuildFullVTable = true;
             }
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void AddEntry(NodeFactory context, MethodDesc virtualMethod)
+        public void AddEntry(NodeFactory factory, MethodDesc virtualMethod)
         {
             Debug.Assert(virtualMethod.IsVirtual);
 
@@ -55,12 +55,12 @@ namespace ILCompiler.DependencyAnalysis
             return "__vtable_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             List<DependencyListEntry> dependencies = new List<DependencyListEntry>();
             if (_type.HasBaseType)
             {
-                dependencies.Add(new DependencyListEntry(context.VTable(_type.BaseType), "Base type VTable"));
+                dependencies.Add(new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable"));
             }
 
             if (_shouldBuildFullVTable)
@@ -76,7 +76,7 @@ namespace ILCompiler.DependencyAnalysis
                     if (!method.IsVirtual)
                         continue;
 
-                    dependencies.Add(new DependencyListEntry(context.VirtualMethodUse(method), "VTable method dependency"));
+                    dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(method), "VTable method dependency"));
                     _slots.Add(method);
                 }
             }
@@ -92,12 +92,12 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -69,17 +69,17 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
         {
             return null;
         }


### PR DESCRIPTION
Half NodeFactory variables were named "context" and the other half were
named "factory". Since "factory" makes more sense, rename all existing
variable names to reduce confusion with TypeSystemContext variables
which also use "context".
